### PR TITLE
Add photo upload module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+/uploads

--- a/src/animal/animal.controller.spec.ts
+++ b/src/animal/animal.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AnimalController } from './animal.controller';
+import { AnimalService } from './animal.service';
 
 describe('AnimalController', () => {
   let controller: AnimalController;
@@ -7,6 +8,7 @@ describe('AnimalController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AnimalController],
+      providers: [{ provide: AnimalService, useValue: {} }],
     }).compile();
 
     controller = module.get<AnimalController>(AnimalController);

--- a/src/animal/animal.service.spec.ts
+++ b/src/animal/animal.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { AnimalService } from './animal.service';
+import { Animal } from './entities/animal.entity';
 
 describe('AnimalService', () => {
   let service: AnimalService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AnimalService],
+      providers: [
+        AnimalService,
+        {
+          provide: getRepositoryToken(Animal),
+          useClass: Repository,
+        },
+      ],
     }).compile();
 
     service = module.get<AnimalService>(AnimalService);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,16 +2,20 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AnimalModule } from './animal/animal.module';
+import { PhotoModule } from './photo/photo.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [AnimalModule,
+  imports: [
+    AnimalModule,
+    PhotoModule,
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'database.sqlite',
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: true,
-    }),],
+    }),
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/photo/entities/photo.entity.ts
+++ b/src/photo/entities/photo.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { Animal } from '../../animal/entities/animal.entity';
+
+@Entity()
+export class Photo {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  path: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => Animal, { onDelete: 'CASCADE', eager: true })
+  animal: Animal;
+}

--- a/src/photo/photo.controller.ts
+++ b/src/photo/photo.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Post, Get, Param, Body, UploadedFile, UseInterceptors, ParseIntPipe, HttpCode, HttpStatus } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { PhotoService } from './photo.service';
+
+@Controller('photo')
+export class PhotoController {
+  constructor(private readonly photoService: PhotoService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseInterceptors(FileInterceptor('file'))
+  create(
+    @UploadedFile() file: Express.Multer.File,
+    @Body('description') description: string,
+    @Body('animalId', ParseIntPipe) animalId: number,
+  ) {
+    return this.photoService.create(file, description, animalId);
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.photoService.findOne(id);
+  }
+
+  @Get()
+  findAll() {
+    return this.photoService.findAll();
+  }
+}

--- a/src/photo/photo.module.ts
+++ b/src/photo/photo.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MulterModule } from '@nestjs/platform-express';
+import { PhotoService } from './photo.service';
+import { PhotoController } from './photo.controller';
+import { Photo } from './entities/photo.entity';
+import { Animal } from '../animal/entities/animal.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Photo, Animal]),
+    MulterModule.register({ dest: './uploads' }),
+  ],
+  providers: [PhotoService],
+  controllers: [PhotoController],
+})
+export class PhotoModule {}

--- a/src/photo/photo.service.ts
+++ b/src/photo/photo.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Photo } from './entities/photo.entity';
+import { Animal } from '../animal/entities/animal.entity';
+
+@Injectable()
+export class PhotoService {
+  constructor(
+    @InjectRepository(Photo)
+    private photoRepository: Repository<Photo>,
+    @InjectRepository(Animal)
+    private animalRepository: Repository<Animal>,
+  ) {}
+
+  async create(file: Express.Multer.File, description: string, animalId: number): Promise<Photo> {
+    const animal = await this.animalRepository.findOneBy({ id: animalId });
+    if (!animal) {
+      throw new NotFoundException(`Animal with ID ${animalId} not found`);
+    }
+    const photo = this.photoRepository.create({
+      path: file.path,
+      description,
+      animal,
+    });
+    return this.photoRepository.save(photo);
+  }
+
+  async findAll(): Promise<Photo[]> {
+    return this.photoRepository.find();
+  }
+
+  async findOne(id: number): Promise<Photo> {
+    const photo = await this.photoRepository.findOneBy({ id });
+    if (!photo) {
+      throw new NotFoundException(`Photo with ID ${id} not found`);
+    }
+    return photo;
+  }
+}


### PR DESCRIPTION
## Summary
- add Photo module with entity referencing animals
- configure Multer for uploads and add `/photo` endpoints
- register PhotoModule in AppModule
- ignore upload folder
- fix unit tests with proper providers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68620f946c70832a965956d0a0e8bce6